### PR TITLE
PlayerAttributes SO and Health Events

### DIFF
--- a/Assets/Events.meta
+++ b/Assets/Events.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c61a0f6fbbd36944aad14daa800a2061
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Events/PlayerHealthEvent.asset
+++ b/Assets/Events/PlayerHealthEvent.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 78d38c138469fe142bb79d457c0ca1c0, type: 3}
+  m_Name: PlayerHealthEvent
+  m_EditorClassIdentifier: 

--- a/Assets/Events/PlayerHealthEvent.asset.meta
+++ b/Assets/Events/PlayerHealthEvent.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 693079bef9e1fa34680c0bb0f161338c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/ShieldGuyWithShield.prefab
+++ b/Assets/Prefabs/ShieldGuyWithShield.prefab
@@ -406,6 +406,7 @@ MonoBehaviour:
     type: 3}
   spriteGuyWithoutShieldFacingLeft: {fileID: 21300000, guid: 855b694ce11b4d54598864636f5cdfd9,
     type: 3}
+  healthEvent: {fileID: 11400000, guid: 693079bef9e1fa34680c0bb0f161338c, type: 2}
 --- !u!114 &215217005
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Spikey Ball Anchor.prefab
+++ b/Assets/Prefabs/Spikey Ball Anchor.prefab
@@ -122,6 +122,7 @@ GameObject:
   - component: {fileID: 7213433344155710465}
   - component: {fileID: 2054704566}
   - component: {fileID: 3323153560613042344}
+  - component: {fileID: 7629987237067667816}
   m_Layer: 0
   m_Name: Spikey Ball Anchor
   m_TagString: Untagged
@@ -188,3 +189,30 @@ MonoBehaviour:
     type: 3}
   pointA: {x: 0, y: 0}
   pointB: {x: 0, y: 0}
+--- !u!114 &7629987237067667816
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6574578955815481556}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c05c80d552970ab4198747be68fd89f8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Event: {fileID: 11400000, guid: 693079bef9e1fa34680c0bb0f161338c, type: 2}
+  Response:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 2054704566}
+        m_MethodName: TestResponse
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2

--- a/Assets/Scenes/DP-Playground.unity
+++ b/Assets/Scenes/DP-Playground.unity
@@ -809,6 +809,11 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 215217004, guid: 37e5e55cf1f3ed44fb6e7635826eba4e, type: 3}
+      propertyPath: attributes
+      value: 
+      objectReference: {fileID: 11400000, guid: a75b5de481b3f974da1ec60b608542bc,
+        type: 2}
     - target: {fileID: 1330292069433469250, guid: 37e5e55cf1f3ed44fb6e7635826eba4e,
         type: 3}
       propertyPath: m_Name

--- a/Assets/ScriptableEventsListeners.meta
+++ b/Assets/ScriptableEventsListeners.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 07bcd4bfc22c0cd4ea04ae1c84a18f9c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptableEventsListeners/PlayerHealthEvent.cs
+++ b/Assets/ScriptableEventsListeners/PlayerHealthEvent.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+[CreateAssetMenu]
+public class PlayerHealthEvent : ScriptableObject
+{
+    private List<PlayerHealthEventListener> subs = new List<PlayerHealthEventListener>();
+
+    public void Raise()
+    {
+        for (int i = subs.Count - 1; i >= 0; --i)
+        {
+            subs[i].OnEventRaised();
+        }
+    }
+
+    public void register(PlayerHealthEventListener listener)
+    {
+        subs.Add(listener);
+    }
+
+    public void unregister(PlayerHealthEventListener listener)
+    {
+        subs.Remove(listener);
+    }
+}

--- a/Assets/ScriptableEventsListeners/PlayerHealthEvent.cs.meta
+++ b/Assets/ScriptableEventsListeners/PlayerHealthEvent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 78d38c138469fe142bb79d457c0ca1c0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptableEventsListeners/PlayerHealthEventListener.cs
+++ b/Assets/ScriptableEventsListeners/PlayerHealthEventListener.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Events;
+
+public class PlayerHealthEventListener : MonoBehaviour
+{
+    public PlayerHealthEvent Event;
+    public UnityEvent Response;
+
+    private void OnEnable()
+    {
+        Event.register(this);
+    }
+
+    private void OnDisable()
+    {
+        Event.unregister(this);
+    }
+
+    public void OnEventRaised()
+    {
+        Response.Invoke();
+    }
+}

--- a/Assets/ScriptableEventsListeners/PlayerHealthEventListener.cs.meta
+++ b/Assets/ScriptableEventsListeners/PlayerHealthEventListener.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c05c80d552970ab4198747be68fd89f8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptableObjects.meta
+++ b/Assets/ScriptableObjects.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 876f6df0ea115b148bc72773500ac627
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptableObjects/PlayerAttributes.asset
+++ b/Assets/ScriptableObjects/PlayerAttributes.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 769c72ef531ef53489417ea1e4beac62, type: 3}
+  m_Name: PlayerAttributes
+  m_EditorClassIdentifier: 
+  initialHealth: 0
+  healthEvent: {fileID: 11400000, guid: 693079bef9e1fa34680c0bb0f161338c, type: 2}

--- a/Assets/ScriptableObjects/PlayerAttributes.asset.meta
+++ b/Assets/ScriptableObjects/PlayerAttributes.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a75b5de481b3f974da1ec60b608542bc
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptableObjects/PlayerAttributes.cs
+++ b/Assets/ScriptableObjects/PlayerAttributes.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+[CreateAssetMenu]
+public class PlayerAttributes : ScriptableObject, ISerializationCallbackReceiver
+{
+    public int initialHealth = 100;
+    public PlayerHealthEvent healthEvent;
+    [NonSerialized] public int _rtHealth;
+
+    public void OnAfterDeserialize()
+    {
+        _rtHealth = initialHealth;
+    }
+
+    public void OnBeforeSerialize()
+    { }
+
+    public int GetHealth()
+    {
+        return _rtHealth;
+    }
+
+    public int LowerHealth(int val)
+    {
+        _rtHealth -= val;
+        Debug.Log("HEALTH LOWERED TO " + _rtHealth + " (-" + val + ")");
+        healthEvent.Raise();
+        return _rtHealth; 
+    }
+
+    public int RaiseHealth(int val)
+    {
+        _rtHealth += val;
+        Debug.Log("HEALTH RAISE TO " + _rtHealth + " (+" + val + ")");
+        healthEvent.Raise();
+        return _rtHealth;
+    }
+
+    public void SetInitHealth(int val)
+    {
+        initialHealth = val;
+        _rtHealth = val;
+    }
+}

--- a/Assets/ScriptableObjects/PlayerAttributes.cs.meta
+++ b/Assets/ScriptableObjects/PlayerAttributes.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 769c72ef531ef53489417ea1e4beac62
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Common/Damager.cs
+++ b/Assets/Scripts/Common/Damager.cs
@@ -20,7 +20,7 @@ public class Damager : MonoBehaviour
     { }
     
     [Header("Properties")]
-    public float damage = 10;
+    public int damage = 10;
     public bool canDamage;
     public bool ignoreInvincibility = false;
     public LayerMask hittableLayers;

--- a/Assets/Scripts/EnvironmentEnemies/SpinSpikeyBall.cs
+++ b/Assets/Scripts/EnvironmentEnemies/SpinSpikeyBall.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 
 public class SpinSpikeyBall : MonoBehaviour
 {
+    private bool stopped = false;
     // Start is called before the first frame update
     void Start()
     {
@@ -13,6 +14,12 @@ public class SpinSpikeyBall : MonoBehaviour
     // Update is called once per frame
     void Update()
     {
+        if (stopped) return;
         transform.Rotate(new Vector3(0, 0, 0.4F));
+    }
+
+    public void TestResponse()
+    {
+        stopped = true;
     }
 }

--- a/Assets/Scripts/Player/PlayerController.cs
+++ b/Assets/Scripts/Player/PlayerController.cs
@@ -13,6 +13,9 @@ namespace Player
         public Sprite spriteGuyWithShieldFacingLeft;
         public Sprite spriteGuyWithoutShieldFacingRight;
         public Sprite spriteGuyWithoutShieldFacingLeft;
+
+        [SerializeField] private PlayerHealthEvent healthEvent;
+        public PlayerAttributes attributes;
         
         // Scripts
         private PlayerMovement _playerMovement;
@@ -24,7 +27,7 @@ namespace Player
         private Sprite _currentLeftFacingSprite;
         private Sprite _currentRightFacingSprite;
 
-        private Damageable _dm;
+        private Damageable _damageable;
         private Rigidbody2D _playerRb;
         
         // Start is called before the first frame update
@@ -34,6 +37,11 @@ namespace Player
             _playerThrowShield = GetComponent<PlayerThrowShield>();
             _spriteRenderer = GetComponent<SpriteRenderer>();
             _playerRb = GetComponent<Rigidbody2D>();
+            
+            attributes.healthEvent = healthEvent;
+            
+            _damageable = GetComponent<Damageable>();
+            _damageable.SetHealth(attributes.initialHealth);
 
             _currentRightFacingSprite = spriteGuyWithShieldFacingRight;
             _currentLeftFacingSprite = spriteGuyWithShieldFacingLeft;
@@ -133,6 +141,7 @@ namespace Player
             print("PLAYER HIT FOR " + damager.damage + " DAMAGE!");
             Vector2 damageDir = (transform.position - damager.transform.position + (UnityEngine.Vector3)damager.offset).normalized;
             _playerRb.AddForce(damageDir * 2F, ForceMode2D.Impulse);
+            attributes.LowerHealth(damager.damage);
         }
 
         public void OnDie(Damager damager, Damageable damageable)


### PR DESCRIPTION
Added a scriptable object to hold the player's current and initial health, and functions that lower/raise health and also raise the HealthEvent for any objects that register for the event.

Made a test function in the spinning spikey balls that stops it's spinning when it gets notified of a Health Event.

I wasn't sure exactly how to instantiate the PlayerAttributes scriptable objects. I made a folder called ScriptableObjects that has the c# script definition along with the asset created from the menu that can be passed into a component. Is that what we're suppose to do? I did the same thing with the HealthEvent object in the ScriptableEventsListeners folder.