### PR TITLE
Prevented damager from continue to damage

### DIFF
--- a/Assets/Prefabs/EnemyWithSpear.prefab
+++ b/Assets/Prefabs/EnemyWithSpear.prefab
@@ -15,7 +15,7 @@ GameObject:
   - component: {fileID: 4937606557088347302}
   - component: {fileID: 2184735412803149406}
   - component: {fileID: 3972935870045659190}
-  m_Layer: 0
+  m_Layer: 10
   m_Name: EnemyWithSpear
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -171,14 +171,17 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   damage: 10
-  canDamage: 0
+  canDamage: 1
   ignoreInvincibility: 0
   hittableLayers:
     serializedVersion: 2
-    m_Bits: 0
+    m_Bits: 256
   movable: 0
   offset: {x: 0.65, y: -0.192}
-  size: {x: 0.8, y: 0.8}
+  size: {x: 0.3, y: 0.3}
+  backoffTime: 0.25
+  indefiniteBackoff: 1
+  active: 1
   OnDamageableEvent:
     m_PersistentCalls:
       m_Calls:
@@ -282,6 +285,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: Spear
+      objectReference: {fileID: 0}
+    - target: {fileID: 4247392507939350701, guid: 5c577aa590770bd4aad55b08492d6169,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 7024710559201799485, guid: 5c577aa590770bd4aad55b08492d6169,
         type: 3}

--- a/Assets/Prefabs/ShieldGuyWithShield.prefab
+++ b/Assets/Prefabs/ShieldGuyWithShield.prefab
@@ -17,7 +17,7 @@ GameObject:
   - component: {fileID: 215216999}
   - component: {fileID: 215217004}
   - component: {fileID: 215217005}
-  m_Layer: 0
+  m_Layer: 8
   m_Name: ShieldGuyWithShield
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -248,36 +248,6 @@ MonoBehaviour:
     m_ActionName: UI/TrackedDeviceOrientation
   - m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 215216998}
-        m_MethodName: ThrowingShield_OnAim
-        m_Mode: 0
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-    m_ActionId: 0b60b1bc-8c1f-4100-9c66-fea3bbb5302a
-    m_ActionName: Aiming Shield/Aim
-  - m_PersistentCalls:
-      m_Calls:
-      - m_Target: {fileID: 215216998}
-        m_MethodName: ThrowingShield_OnFire
-        m_Mode: 0
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-    m_ActionId: ca7524d7-6d02-435c-a11f-8cd3d41d753a
-    m_ActionName: Aiming Shield/Throw[/DualShock4GamepadHID/buttonNorth]
-  - m_PersistentCalls:
-      m_Calls:
       - m_Target: {fileID: 215217004}
         m_MethodName: IG_Player_OnJump
         m_Mode: 0
@@ -407,6 +377,7 @@ MonoBehaviour:
   spriteGuyWithoutShieldFacingLeft: {fileID: 21300000, guid: 855b694ce11b4d54598864636f5cdfd9,
     type: 3}
   healthEvent: {fileID: 11400000, guid: 693079bef9e1fa34680c0bb0f161338c, type: 2}
+  attributes: {fileID: 11400000, guid: a75b5de481b3f974da1ec60b608542bc, type: 2}
 --- !u!114 &215217005
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -423,4 +394,3 @@ MonoBehaviour:
   jumpForce: 7
   thrust: 15
   maxVelocity: 5
-  floatHeight: 0

--- a/Assets/Prefabs/Spikey Ball Anchor.prefab
+++ b/Assets/Prefabs/Spikey Ball Anchor.prefab
@@ -9,7 +9,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 5039808704910632241}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: Hitbox Center
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -40,7 +40,7 @@ GameObject:
   m_Component:
   - component: {fileID: 7393151237480555727}
   - component: {fileID: 3234267899491034321}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: SpikeyBall
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -123,7 +123,7 @@ GameObject:
   - component: {fileID: 2054704566}
   - component: {fileID: 3323153560613042344}
   - component: {fileID: 7629987237067667816}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: Spikey Ball Anchor
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -175,10 +175,13 @@ MonoBehaviour:
   ignoreInvincibility: 0
   hittableLayers:
     serializedVersion: 2
-    m_Bits: 1
+    m_Bits: 256
   movable: 1
   offset: {x: 0, y: 1.025}
   size: {x: 0.8, y: 0.8}
+  backoffTime: 0.5
+  indefiniteBackoff: 0
+  active: 1
   OnDamageableEvent:
     m_PersistentCalls:
       m_Calls: []

--- a/Assets/Prefabs/Vertical Floating Spikey Ball.prefab
+++ b/Assets/Prefabs/Vertical Floating Spikey Ball.prefab
@@ -11,7 +11,8 @@ GameObject:
   - component: {fileID: 6602692705318652966}
   - component: {fileID: 1099583743237449182}
   - component: {fileID: 6942079894656986418}
-  m_Layer: 0
+  - component: {fileID: 1052744094}
+  m_Layer: 9
   m_Name: Vertical Floating Spikey Ball
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -94,5 +95,39 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5662664de7b1d984db1469707f7ceb95, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  patrolDistance: 5
-  speed: 10
+  patrolDistance: 2
+  speed: 2
+--- !u!114 &1052744094
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6635988591190806110}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4503667ff6b329e42a9f69626e054caf, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  damage: 10
+  canDamage: 1
+  ignoreInvincibility: 0
+  hittableLayers:
+    serializedVersion: 2
+    m_Bits: 256
+  movable: 0
+  offset: {x: 0, y: 0}
+  size: {x: 0.8, y: 0.8}
+  backoffTime: 0.5
+  indefiniteBackoff: 0
+  active: 1
+  OnDamageableEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  OnNonDamageableEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  debugPointPrefab: {fileID: 9173607954042685336, guid: 6cefa1844677a3e42802a6fc90a88f67,
+    type: 3}
+  pointA: {x: 0, y: 0}
+  pointB: {x: 0, y: 0}

--- a/Assets/Prefabs/shield.prefab
+++ b/Assets/Prefabs/shield.prefab
@@ -31,7 +31,8 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: -3.639, y: -2.638, z: 0}
   m_LocalScale: {x: 1.4073203, y: 1.4073203, z: 1.4073203}
-  m_Children: []
+  m_Children:
+  - {fileID: 4925083850324129869}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -159,12 +160,54 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   damage: 10
+  canDamage: 1
+  ignoreInvincibility: 0
+  hittableLayers:
+    serializedVersion: 2
+    m_Bits: 1536
+  movable: 1
+  offset: {x: 0, y: 0}
+  size: {x: 0.5, y: 0.5}
+  backoffTime: 0.25
+  indefiniteBackoff: 0
+  active: 1
   OnDamageableEvent:
     m_PersistentCalls:
       m_Calls: []
   OnNonDamageableEvent:
     m_PersistentCalls:
       m_Calls: []
-  hittableLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
+  debugPointPrefab: {fileID: 9173607954042685336, guid: 6cefa1844677a3e42802a6fc90a88f67,
+    type: 3}
+  pointA: {x: 0, y: 0}
+  pointB: {x: 0, y: 0}
+--- !u!1 &7898747920012305571
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4925083850324129869}
+  m_Layer: 0
+  m_Name: Hitbox Center
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4925083850324129869
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7898747920012305571}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.71057034, y: 0.71057034, z: 0.71057034}
+  m_Children: []
+  m_Father: {fileID: 3675948955171397363}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Scenes/DP-Playground.unity
+++ b/Assets/Scenes/DP-Playground.unity
@@ -396,35 +396,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3972935870045659190, guid: 7ace052469440a149acaa250731a8b11,
-        type: 3}
-      propertyPath: size.x
-      value: 0.3
-      objectReference: {fileID: 0}
-    - target: {fileID: 3972935870045659190, guid: 7ace052469440a149acaa250731a8b11,
-        type: 3}
-      propertyPath: size.y
-      value: 0.3
-      objectReference: {fileID: 0}
-    - target: {fileID: 3972935870045659190, guid: 7ace052469440a149acaa250731a8b11,
-        type: 3}
-      propertyPath: canDamage
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 3972935870045659190, guid: 7ace052469440a149acaa250731a8b11,
-        type: 3}
-      propertyPath: hittableLayers.m_Bits
-      value: 1
-      objectReference: {fileID: 0}
     - target: {fileID: 5205605759791943605, guid: 7ace052469440a149acaa250731a8b11,
         type: 3}
       propertyPath: m_Name
       value: EnemyWithSpear
-      objectReference: {fileID: 0}
-    - target: {fileID: 7330317961770868167, guid: 7ace052469440a149acaa250731a8b11,
-        type: 3}
-      propertyPath: m_Simulated
-      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 7ace052469440a149acaa250731a8b11, type: 3}
@@ -558,43 +533,6 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1052744093 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 6635988591190806110, guid: 62fa9b42add40654395ee9852229b285,
-    type: 3}
-  m_PrefabInstance: {fileID: 1453422769}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &1052744094
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1052744093}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4503667ff6b329e42a9f69626e054caf, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  damage: 10
-  canDamage: 1
-  ignoreInvincibility: 0
-  hittableLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  movable: 0
-  offset: {x: 0, y: 0}
-  size: {x: 0.8, y: 0.8}
-  OnDamageableEvent:
-    m_PersistentCalls:
-      m_Calls: []
-  OnNonDamageableEvent:
-    m_PersistentCalls:
-      m_Calls: []
-  debugPointPrefab: {fileID: 9173607954042685336, guid: 6cefa1844677a3e42802a6fc90a88f67,
-    type: 3}
-  pointA: {x: 0, y: 0}
-  pointB: {x: 0, y: 0}
 --- !u!1 &1091087132
 GameObject:
   m_ObjectHideFlags: 0
@@ -809,11 +747,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 215217004, guid: 37e5e55cf1f3ed44fb6e7635826eba4e, type: 3}
-      propertyPath: attributes
-      value: 
-      objectReference: {fileID: 11400000, guid: a75b5de481b3f974da1ec60b608542bc,
-        type: 2}
     - target: {fileID: 1330292069433469250, guid: 37e5e55cf1f3ed44fb6e7635826eba4e,
         type: 3}
       propertyPath: m_Name
@@ -942,16 +875,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: Vertical Floating Spikey Ball
-      objectReference: {fileID: 0}
-    - target: {fileID: 6942079894656986418, guid: 62fa9b42add40654395ee9852229b285,
-        type: 3}
-      propertyPath: speed
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 6942079894656986418, guid: 62fa9b42add40654395ee9852229b285,
-        type: 3}
-      propertyPath: patrolDistance
-      value: 2
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 62fa9b42add40654395ee9852229b285, type: 3}
@@ -1092,14 +1015,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 246097038, guid: 5bbd17b053aff0846bb0d2e00831ac12, type: 3}
-      propertyPath: canDamage
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 246097038, guid: 5bbd17b053aff0846bb0d2e00831ac12, type: 3}
-      propertyPath: hittableLayers.m_Bits
-      value: 1
-      objectReference: {fileID: 0}
     - target: {fileID: 6574578955815481556, guid: 5bbd17b053aff0846bb0d2e00831ac12,
         type: 3}
       propertyPath: m_Name

--- a/Assets/ScriptableObjects/PlayerAttributes.asset
+++ b/Assets/ScriptableObjects/PlayerAttributes.asset
@@ -12,5 +12,5 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 769c72ef531ef53489417ea1e4beac62, type: 3}
   m_Name: PlayerAttributes
   m_EditorClassIdentifier: 
-  initialHealth: 0
+  initialHealth: 100
   healthEvent: {fileID: 11400000, guid: 693079bef9e1fa34680c0bb0f161338c, type: 2}

--- a/Assets/Scripts/Utility.meta
+++ b/Assets/Scripts/Utility.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1fe5e6f2eac508b44b5432ddb82d6813
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Utility/CameraFollow.cs.meta
+++ b/Assets/Scripts/Utility/CameraFollow.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9fe66f01302214a44a13c039a16ec7e3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -6,6 +6,7 @@ TagManager:
   tags:
   - Ground
   - Shield
+  - Spear
   layers:
   - Default
   - TransparentFX
@@ -15,9 +16,9 @@ TagManager:
   - UI
   - 
   - 
-  - 
-  - 
-  - 
+  - Player
+  - Environment
+  - Enemies
   - 
   - 
   - 


### PR DESCRIPTION
The damager now does a backoff time so that it cannot immediately do damage on the next frame. The backoff time is set in the editor. Also added an indefinite backoff where the damager remains unactive until manually set as active.

Did it this way after I tried to save the objects being collided with but Physics2D.OverlapArea function is not always consistent in remembering which objects have already been collided with. (Maybe I was doing it wrong though, it just never removed the collision from a list after it was registered).

Fixed some bugs with the shield, made it's damager moveable so that it moves with the shield as it's flying through the air.

I also found that the damager does not rotate with the object because it's bounding box is only based on the offset from the parents position. In the future we might need to figure out the rotation of the damager based on the parent's rotation.