### PR TITLE
Bug Fixes

### DIFF
--- a/Assets/ScriptableObjects/Decisions.meta
+++ b/Assets/ScriptableObjects/Decisions.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 96f7e35349b8a064fb72772f45aa9baa
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptableObjects/States.meta
+++ b/Assets/ScriptableObjects/States.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8d9460d91522d044e90a88dbc9fa625c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptableObjects/States/EmptyState.asset
+++ b/Assets/ScriptableObjects/States/EmptyState.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b7c690405f024a745804e048dba5b9b1, type: 3}
+  m_Name: EmptyState
+  m_EditorClassIdentifier: 
+  actions: []
+  transitions: []

--- a/Assets/ScriptableObjects/States/EmptyState.asset.meta
+++ b/Assets/ScriptableObjects/States/EmptyState.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2aa2b5f743f089c4b877f499b5075f50
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptableObjects/Transitions.meta
+++ b/Assets/ScriptableObjects/Transitions.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 552011a781ca15a4597ae791719cb02a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Player/PlayerController.cs
+++ b/Assets/Scripts/Player/PlayerController.cs
@@ -20,7 +20,7 @@ namespace Player
         private PlayerMovement _playerMovement;
 
         // Private variables
-        private StateController _state;
+        private Player.StateController _state;
         private SpriteRenderer _spriteRenderer;
         private Sprite _currentLeftFacingSprite;
         private Sprite _currentRightFacingSprite;
@@ -124,8 +124,8 @@ namespace Player
         public void OnFire(InputAction.CallbackContext context)
         {
             // check fire conditions
-            if (!_state.HasShield && !_state.IsAiming && !context.started) return;
-            
+            if (!_state.HasShield && !_state.IsAiming /*&& !context.started*/) return;
+
             var selfPos = transform.position;
             var spawnPos = selfPos + new Vector3(1.5f, 0f, 0f);
 


### PR DESCRIPTION
The player could throw a shield event if they didn't have one. Took out the check for context.started because it was letting it through on the next call (even when the other values were false for some reason)

Added a default empty state for the AI StateController to prevent the error for the currentState being null.

Added some folders under ScriptableObjects for Decisions, States, and Transitions for later if we need them. 