### PR TITLE
Updated basic player movement

### DIFF
--- a/Assets/Art/ParticleEffects.meta
+++ b/Assets/Art/ParticleEffects.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 81528222b515b334499017dcbec2e764
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Materials/Ground.physicsMaterial2D
+++ b/Assets/Materials/Ground.physicsMaterial2D
@@ -1,0 +1,11 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!62 &6200000
+PhysicsMaterial2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Ground
+  friction: 0.1
+  bounciness: 0

--- a/Assets/Materials/Ground.physicsMaterial2D.meta
+++ b/Assets/Materials/Ground.physicsMaterial2D.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9c240e23c68b1c74c9fe6f3f4cad29ac
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/ShieldGuyWithShield.prefab
+++ b/Assets/Prefabs/ShieldGuyWithShield.prefab
@@ -11,11 +11,11 @@ GameObject:
   - component: {fileID: 1330292069433469254}
   - component: {fileID: 1330292069433469255}
   - component: {fileID: 1330292069433469248}
-  - component: {fileID: 1330292069433469249}
   - component: {fileID: 4448174030051616573}
   - component: {fileID: 215216999}
   - component: {fileID: 215217004}
   - component: {fileID: 215217005}
+  - component: {fileID: 1440739262}
   m_Layer: 8
   m_Name: ShieldGuyWithShield
   m_TagString: Untagged
@@ -35,6 +35,7 @@ Transform:
   m_LocalScale: {x: 1.489899, y: 1.489899, z: 1.489899}
   m_Children:
   - {fileID: 4918096529508721530}
+  - {fileID: 4986686378411245047}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -107,34 +108,8 @@ Rigidbody2D:
   m_Material: {fileID: 0}
   m_Interpolate: 0
   m_SleepingMode: 1
-  m_CollisionDetection: 0
+  m_CollisionDetection: 1
   m_Constraints: 4
---- !u!61 &1330292069433469249
-BoxCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1330292069433469250}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
-  m_SpriteTilingProperty:
-    border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0.5, y: 0.5}
-    oldSize: {x: 0.53, y: 0.99}
-    newSize: {x: 0.53, y: 0.99}
-    adaptiveTilingThreshold: 0.5
-    drawMode: 0
-    adaptiveTiling: 0
-  m_AutoTiling: 0
-  serializedVersion: 2
-  m_Size: {x: 0.53, y: 0.99}
-  m_EdgeRadius: 0
 --- !u!114 &4448174030051616573
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -376,8 +351,27 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   gravityMultiplier: 2
   jumpForce: 7
-  thrust: 15
+  thrust: 17
   maxVelocity: 5
+  jumpUpSlowDownMultiplier: 0.5
+  jumpFallMultiplier: 1.01
+  runningTractionMultiplier: 0.95
+--- !u!70 &1440739262
+CapsuleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1330292069433469250}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_Size: {x: 0.53, y: 0.99}
+  m_Direction: 0
 --- !u!1 &1524277336191385835
 GameObject:
   m_ObjectHideFlags: 0
@@ -423,6 +417,36 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   currentAngle: 0
+--- !u!1 &2732567059192612844
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7893824545719101382}
+  m_Layer: 0
+  m_Name: Right Ground Distance Caster
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7893824545719101382
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2732567059192612844}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0.744, y: -0.854, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4986686378411245047}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &5701709897492257116
 GameObject:
   m_ObjectHideFlags: 0
@@ -504,3 +528,65 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!1 &5709130455566393707
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5409908148141150940}
+  m_Layer: 0
+  m_Name: Left Ground Distance Caster
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5409908148141150940
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5709130455566393707}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0.226, y: -0.854, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4986686378411245047}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &8057500484811857946
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4986686378411245047}
+  m_Layer: 0
+  m_Name: Casters
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4986686378411245047
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8057500484811857946}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0.28999522, y: 0.08254979, z: -0.027711209}
+  m_LocalScale: {x: 0.67118645, y: 0.67118645, z: 0.67118645}
+  m_Children:
+  - {fileID: 5409908148141150940}
+  - {fileID: 7893824545719101382}
+  m_Father: {fileID: 1330292069433469254}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Scenes/DP-Playground.unity
+++ b/Assets/Scenes/DP-Playground.unity
@@ -468,10 +468,10 @@ Rigidbody2D:
   m_LinearDrag: 0
   m_AngularDrag: 0.05
   m_GravityScale: 1
-  m_Material: {fileID: 0}
+  m_Material: {fileID: 6200000, guid: 9c240e23c68b1c74c9fe6f3f4cad29ac, type: 2}
   m_Interpolate: 0
   m_SleepingMode: 1
-  m_CollisionDetection: 0
+  m_CollisionDetection: 1
   m_Constraints: 7
 --- !u!212 &664760702
 SpriteRenderer:
@@ -598,7 +598,7 @@ Rigidbody2D:
   m_LinearDrag: 0
   m_AngularDrag: 0.05
   m_GravityScale: 1
-  m_Material: {fileID: 0}
+  m_Material: {fileID: 6200000, guid: 9c240e23c68b1c74c9fe6f3f4cad29ac, type: 2}
   m_Interpolate: 0
   m_SleepingMode: 1
   m_CollisionDetection: 0
@@ -751,6 +751,22 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 215217004, guid: 37e5e55cf1f3ed44fb6e7635826eba4e, type: 3}
+      propertyPath: _leftBufferRayPosition
+      value: 
+      objectReference: {fileID: 1386152016}
+    - target: {fileID: 215217004, guid: 37e5e55cf1f3ed44fb6e7635826eba4e, type: 3}
+      propertyPath: _rightBufferRayPosition
+      value: 
+      objectReference: {fileID: 1386152015}
+    - target: {fileID: 215217004, guid: 37e5e55cf1f3ed44fb6e7635826eba4e, type: 3}
+      propertyPath: _minDistanceToBufferJump
+      value: 0.4
+      objectReference: {fileID: 0}
+    - target: {fileID: 215217004, guid: 37e5e55cf1f3ed44fb6e7635826eba4e, type: 3}
+      propertyPath: _jumpBufferLayerMask.m_Bits
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 1330292069433469250, guid: 37e5e55cf1f3ed44fb6e7635826eba4e,
         type: 3}
       propertyPath: m_Name
@@ -813,6 +829,18 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 37e5e55cf1f3ed44fb6e7635826eba4e, type: 3}
+--- !u!4 &1386152015 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7893824545719101382, guid: 37e5e55cf1f3ed44fb6e7635826eba4e,
+    type: 3}
+  m_PrefabInstance: {fileID: 1386152014}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1386152016 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5409908148141150940, guid: 37e5e55cf1f3ed44fb6e7635826eba4e,
+    type: 3}
+  m_PrefabInstance: {fileID: 1386152014}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1453422769
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -943,7 +971,7 @@ Rigidbody2D:
   m_LinearDrag: 0
   m_AngularDrag: 0.05
   m_GravityScale: 1
-  m_Material: {fileID: 0}
+  m_Material: {fileID: 6200000, guid: 9c240e23c68b1c74c9fe6f3f4cad29ac, type: 2}
   m_Interpolate: 0
   m_SleepingMode: 1
   m_CollisionDetection: 0

--- a/Assets/ScriptableObjects/PlayerAttributes.cs
+++ b/Assets/ScriptableObjects/PlayerAttributes.cs
@@ -26,7 +26,7 @@ public class PlayerAttributes : ScriptableObject, ISerializationCallbackReceiver
     public int LowerHealth(int val)
     {
         _rtHealth -= val;
-        Debug.Log("HEALTH LOWERED TO " + _rtHealth + " (-" + val + ")");
+        // Debug.Log("HEALTH LOWERED TO " + _rtHealth + " (-" + val + ")");
         healthEvent.Raise();
         return _rtHealth; 
     }
@@ -34,7 +34,7 @@ public class PlayerAttributes : ScriptableObject, ISerializationCallbackReceiver
     public int RaiseHealth(int val)
     {
         _rtHealth += val;
-        Debug.Log("HEALTH RAISE TO " + _rtHealth + " (+" + val + ")");
+        // Debug.Log("HEALTH RAISE TO " + _rtHealth + " (+" + val + ")");
         healthEvent.Raise();
         return _rtHealth;
     }

--- a/Assets/Scripts/Player/PlayerMovement.cs
+++ b/Assets/Scripts/Player/PlayerMovement.cs
@@ -14,6 +14,13 @@ namespace Player
         public float jumpForce = 150f;
         public float thrust = 100f;
         public float maxVelocity = 10f;
+        [Tooltip("How much to slow down moving upwards after the jump button is released")]
+        public float jumpUpSlowDownMultiplier = 0.5f;
+        [Tooltip("How fast the player should accelerate towards the ground after falling from a jump")]
+        public float jumpFallMultiplier = 1.01f;
+        [Tooltip("How fast the player can slow down")]
+        [Range(0.0F, 1.0F)]
+        public float runningTractionMultiplier = 0.85f;
 
         private void Start()
         {
@@ -22,9 +29,26 @@ namespace Player
             Physics2D.gravity *= gravityMultiplier;
         }
 
-        public void OnJump()
+        public void Update()
         {
-            _rigidbody2D.AddForce(Vector2.up * jumpForce, ForceMode2D.Impulse);
+            if (_rigidbody2D.velocity.y < 0)
+            {
+                _rigidbody2D.velocity = new Vector2(_rigidbody2D.velocity.x, _rigidbody2D.velocity.y * jumpFallMultiplier);
+            }
+        }
+
+        public void OnJump(bool pressed = true)
+        {
+            if (pressed)
+            {
+                _rigidbody2D.AddForce(Vector2.up * jumpForce, ForceMode2D.Impulse);
+            }
+            else if (!pressed && _rigidbody2D.velocity.y > 0)
+            {
+                // this will get called again when the button is released
+                // this will let the player do a small jump or a big jump based on when they release the button
+                _rigidbody2D.velocity = new Vector2(_rigidbody2D.velocity.x, _rigidbody2D.velocity.y * jumpUpSlowDownMultiplier);
+            }
         }
 
         public void OnMove(Vector2 input)
@@ -37,6 +61,11 @@ namespace Player
             if (_rigidbody2D.velocity.magnitude < maxVelocity)
             {
                 _rigidbody2D.AddForce(_momentumVector * thrust, ForceMode2D.Force);
+            }
+
+            if (_momentumVector == Vector2.zero)
+            {
+                _rigidbody2D.velocity = new Vector2(_rigidbody2D.velocity.x * runningTractionMultiplier, _rigidbody2D.velocity.y);
             }
         }
 

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -19,7 +19,7 @@ TagManager:
   - Player
   - Environment
   - Enemies
-  - 
+  - Walkables
   - 
   - 
   - 


### PR DESCRIPTION
Long pressing the jump button makes the player jump higher, short pressing makes a shorter jump.

Added acceleration when falling from a jump so that the player moves faster on the way down than they did on the way up. Letting go of the jump button mid-jump makes the player's speed decrease until the start falling back down.

Added a jump buffer so that depending on how close to the ground after a jump the player was when they re-pressed the jump button, the jump will happen again so that it doesn't feel like the input got lost. The distance from the ground is set in a variable in the PlayerMovement script so we can play with it.

Added a variable that controls how fast the player stops when they stop running. This way we can set the friction of the ground and decide how far the player should slide (thinking about ice vs. sand or something like that).