### PR TITLE
Added camera shake

### DIFF
--- a/Assets/Events/CameraShakeEvent.asset
+++ b/Assets/Events/CameraShakeEvent.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 92d879b2e772e7d4b9a5f372e20d08f5, type: 3}
+  m_Name: CameraShakeEvent
+  m_EditorClassIdentifier: 

--- a/Assets/Events/CameraShakeEvent.asset.meta
+++ b/Assets/Events/CameraShakeEvent.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2bd429db919654e4a88ecd3da577e5ac
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Materials/Shield.physicsMaterial2D
+++ b/Assets/Materials/Shield.physicsMaterial2D
@@ -1,0 +1,11 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!62 &6200000
+PhysicsMaterial2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Shield
+  friction: 0.4
+  bounciness: 0.1

--- a/Assets/Materials/Shield.physicsMaterial2D.meta
+++ b/Assets/Materials/Shield.physicsMaterial2D.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 117034957e2fafb4e8c7279a3cce8c5e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/shield.prefab
+++ b/Assets/Prefabs/shield.prefab
@@ -128,10 +128,10 @@ Rigidbody2D:
   m_LinearDrag: 0
   m_AngularDrag: 0.05
   m_GravityScale: 1
-  m_Material: {fileID: 0}
-  m_Interpolate: 0
+  m_Material: {fileID: 6200000, guid: 117034957e2fafb4e8c7279a3cce8c5e, type: 2}
+  m_Interpolate: 1
   m_SleepingMode: 1
-  m_CollisionDetection: 0
+  m_CollisionDetection: 1
   m_Constraints: 0
 --- !u!114 &1779618034260880428
 MonoBehaviour:
@@ -145,6 +145,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 547470cad68658b4595cfea9136cad5c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  cameraShakeEvent: {fileID: 11400000, guid: 2bd429db919654e4a88ecd3da577e5ac, type: 2}
+  cameraShakeIntensitity: 5
+  cameraShakeDuration: 0.2
   sparks: {fileID: 0}
 --- !u!114 &2430950548349681625
 MonoBehaviour:
@@ -175,8 +178,6 @@ MonoBehaviour:
   OnNonDamageableEvent:
     m_PersistentCalls:
       m_Calls: []
-  debugPointPrefab: {fileID: 9173607954042685336, guid: 6cefa1844677a3e42802a6fc90a88f67,
-    type: 3}
   pointA: {x: 0, y: 0}
   pointB: {x: 0, y: 0}
 --- !u!1 &7898747920012305571

--- a/Assets/Scenes/DP-Playground.unity
+++ b/Assets/Scenes/DP-Playground.unity
@@ -262,6 +262,7 @@ GameObject:
   - component: {fileID: 446534556}
   - component: {fileID: 446534558}
   - component: {fileID: 446534557}
+  - component: {fileID: 446534559}
   m_Layer: 0
   m_Name: cm
   m_TagString: Untagged
@@ -338,6 +339,23 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ac0b09e7857660247b1477e93731de29, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &446534559
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 446534555}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 68bb026fafb42b14791938953eaace77, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_NoiseProfile: {fileID: 11400000, guid: 69ce8388f6785dd4c8c39915efece2f4, type: 2}
+  m_PivotOffset: {x: 0, y: 0, z: 0}
+  m_AmplitudeGain: 0
+  m_FrequencyGain: 1
+  mNoiseOffsets: {x: 0, y: 0, z: 0}
 --- !u!1 &519420028
 GameObject:
   m_ObjectHideFlags: 0
@@ -2803,6 +2821,8 @@ GameObject:
   m_Component:
   - component: {fileID: 1721507163}
   - component: {fileID: 1721507162}
+  - component: {fileID: 1721507165}
+  - component: {fileID: 1721507164}
   m_Layer: 0
   m_Name: CM vcam1
   m_TagString: Untagged
@@ -2839,7 +2859,7 @@ MonoBehaviour:
     ModeOverride: 0
     LensShift: {x: 0, y: 0}
     GateFit: 2
-    m_SensorSize: {x: 1.7776607, y: 1}
+    m_SensorSize: {x: 1.7775401, y: 1}
   m_Transitions:
     m_BlendHint: 0
     m_InheritPosition: 0
@@ -2863,6 +2883,45 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 11
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1721507164
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1721507161}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fb74b5767b921a442a8621d2f25570f9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Event: {fileID: 11400000, guid: 2bd429db919654e4a88ecd3da577e5ac, type: 2}
+  Response:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1721507165}
+        m_MethodName: ShakeCamera
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &1721507165
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1721507161}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c278514d8dd17334f99fcc171babb350, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1862325365
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/ScriptableEventsListeners/CameraShakeEvent.cs
+++ b/Assets/ScriptableEventsListeners/CameraShakeEvent.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+[CreateAssetMenu (menuName = "Events/Camera/Shake")]
+public class CameraShakeEvent : ScriptableObject
+{
+    private List<CameraShakeEventListener> subs = new List<CameraShakeEventListener>();
+
+    public void Raise(float intensity, float time)
+    {
+        for (int i = subs.Count - 1; i >= 0; --i)
+        {
+            subs[i].OnEventRaised(intensity, time);
+        }
+    }
+
+    public void register(CameraShakeEventListener listener)
+    {
+        subs.Add(listener);
+    }
+
+    public void unregister(CameraShakeEventListener listener)
+    {
+        subs.Remove(listener);
+    }
+}

--- a/Assets/ScriptableEventsListeners/CameraShakeEvent.cs.meta
+++ b/Assets/ScriptableEventsListeners/CameraShakeEvent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 92d879b2e772e7d4b9a5f372e20d08f5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptableEventsListeners/CameraShakeEventListener.cs
+++ b/Assets/ScriptableEventsListeners/CameraShakeEventListener.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Events;
+
+public class CameraShakeEventListener : MonoBehaviour
+{
+
+    public CameraShakeEvent Event;
+    public C_CameraShakeEvent Response;
+    
+    private void OnEnable()
+    {
+        Event.register(this);
+    }
+
+    private void OnDisable()
+    {
+        Event.unregister(this);
+    }
+
+    public void OnEventRaised(float intensity, float time)
+    {
+        Response.Invoke(intensity, time);
+    }
+}

--- a/Assets/ScriptableEventsListeners/CameraShakeEventListener.cs.meta
+++ b/Assets/ScriptableEventsListeners/CameraShakeEventListener.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fb74b5767b921a442a8621d2f25570f9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptableEventsListeners/PlayerHealthEvent.cs
+++ b/Assets/ScriptableEventsListeners/PlayerHealthEvent.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using UnityEngine;
 
-[CreateAssetMenu]
+[CreateAssetMenu (menuName = "Events/Player/Health")]
 public class PlayerHealthEvent : ScriptableObject
 {
     private List<PlayerHealthEventListener> subs = new List<PlayerHealthEventListener>();

--- a/Assets/Scripts/Camera.meta
+++ b/Assets/Scripts/Camera.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9bf84c83e199d7144969ea16a14e8e71
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Camera/CameraController.cs
+++ b/Assets/Scripts/Camera/CameraController.cs
@@ -1,0 +1,38 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using Cinemachine;
+using UnityEngine;
+
+public class CameraController : MonoBehaviour
+{
+    private CinemachineVirtualCamera _virtualCamera;
+    private CinemachineBasicMultiChannelPerlin _virtualCameraBMCP;
+    private float shakeTimer;
+    private float totalShakeTime;
+    private float startingIntensity;
+    
+    // Start is called before the first frame update
+    void Start()
+    {
+        _virtualCamera = GetComponent<CinemachineVirtualCamera>();
+        _virtualCameraBMCP = _virtualCamera.GetCinemachineComponent<CinemachineBasicMultiChannelPerlin>();
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        if (shakeTimer > 0)
+        {
+            shakeTimer -= Time.deltaTime;
+            _virtualCameraBMCP.m_AmplitudeGain = Mathf.Lerp(0F, startingIntensity, shakeTimer / totalShakeTime);
+        }
+    }
+
+    public void ShakeCamera(float intensity, float time)
+    {
+        print("SHAKING! " + intensity + " " + time);
+        startingIntensity = intensity;
+        shakeTimer = time;
+        totalShakeTime = time;
+    }
+}

--- a/Assets/Scripts/Camera/CameraController.cs.meta
+++ b/Assets/Scripts/Camera/CameraController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c278514d8dd17334f99fcc171babb350
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/CustomUnityEvents.meta
+++ b/Assets/Scripts/CustomUnityEvents.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 577f7e1a984e632428eaafe23dfc01c1
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/CustomUnityEvents/C_CameraShakeEvent.cs
+++ b/Assets/Scripts/CustomUnityEvents/C_CameraShakeEvent.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Events;
+
+[Serializable]
+public class C_CameraShakeEvent : UnityEvent<float, float>
+{
+}

--- a/Assets/Scripts/CustomUnityEvents/C_CameraShakeEvent.cs.meta
+++ b/Assets/Scripts/CustomUnityEvents/C_CameraShakeEvent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1faec95696620764aaf94a9ef58c479a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Weapons/Shields/ShieldController.cs
+++ b/Assets/Scripts/Weapons/Shields/ShieldController.cs
@@ -7,6 +7,11 @@ using Vector3 = UnityEngine.Vector3;
 
 public class ShieldController : MonoBehaviour
 {
+    public CameraShakeEvent cameraShakeEvent;
+    public float cameraShakeIntensitity;
+    public float cameraShakeDuration;
+    
+    
     private Vector3 forceDirection;
     
     private Rigidbody2D shieldRb;
@@ -27,6 +32,7 @@ public class ShieldController : MonoBehaviour
         //shieldRb.AddForce(forceDir * 30, ForceMode2D.Impulse);
         shieldRb.AddForce(forceDirection * 30, ForceMode2D.Impulse);
         shieldRb.AddTorque(5, ForceMode2D.Impulse);
+        cameraShakeEvent.Raise(cameraShakeIntensitity, cameraShakeDuration);
     }
 
     private void OnCollisionEnter2D(Collision2D other)


### PR DESCRIPTION
Added a camera shake event and listener (scriptable object event system) that uses a custom UnityEvent class called C_CameraShakeEvent so that the object that invokes the event can pass the variables necessary to control the shake amount and duration.

Also added a physics material to the shield to have it bounce more after being thrown. When throwing the shield, the shield prefab invokes the camera shake event just to test (we don't need to keep the shake on throw, maybe on collision instead)